### PR TITLE
Release v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-flash/stream",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/open-flash/stream",
   "description": "Streams for Open Flash",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Fix]**: `writeUint32Leb128` now supports integers larger than 2^31