### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.2.0 (2019-11-25)
 
 - **[Breaking change]** Require Node `13.2`.
 - **[Breaking change]** Replace `readString` and `readCString` with checked `readUtf8` and `readNulTerminatedString`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-flash/stream",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/open-flash/stream",
   "description": "Streams for Open Flash",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Breaking change]** Require Node `13.2`.
- **[Breaking change]** Replace `readString` and `readCString` with checked `readUtf8` and `readNulTerminatedString`.
- **[Fix]** Create `CHANGELOG.md`.
- **[Fix]** Update dependencies.