### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Breaking change]** Rename `readNulTerminatedUtf8` to `readNulUtf8` and `writeNulTerminatedUtf8` to `writeNulUtf8`.
+
 # 0.2.1 (2019-11-25)
 
 - **[Internal]** Fix continuous deployment script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.3.0 (2020-01-16)
 
 - **[Breaking change]** Rename `readNulTerminatedUtf8` to `readNulUtf8` and `writeNulTerminatedUtf8` to `writeNulUtf8`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-flash/stream",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "homepage": "https://github.com/open-flash/stream",
   "description": "Streams for Open Flash",
   "main": "dist/lib/index.js",

--- a/src/lib/readable.ts
+++ b/src/lib/readable.ts
@@ -60,7 +60,7 @@ export interface ReadableByteStream {
    *
    * The `NUL` byte is consumed but not included in the result.
    */
-  readNulTerminatedUtf8(): string;
+  readNulUtf8(): string;
 
   readUint8(): Uint8;
 
@@ -340,7 +340,7 @@ export class ReadableStream implements ReadableBitStream, ReadableByteStream {
     return result;
   }
 
-  readNulTerminatedUtf8(): string {
+  readNulUtf8(): string {
     const endOfString: number = this.bytes.indexOf(0, this.bytePos);
     if (endOfString < 0) {
       throw createIncompleteStreamError();

--- a/src/lib/writable.ts
+++ b/src/lib/writable.ts
@@ -44,7 +44,7 @@ export interface WritableByteStream {
 
   writeUtf8(value: string): void;
 
-  writeNulTerminatedUtf8(value: string): void;
+  writeNulUtf8(value: string): void;
 
   writeUint8(value: Uint8): void;
 
@@ -271,7 +271,7 @@ export class WritableStream implements WritableBitStream, WritableByteStream {
     this.writeBytes(UTF8_ENCODER.encode(value));
   }
 
-  writeNulTerminatedUtf8(value: string): void {
+  writeNulUtf8(value: string): void {
     this.writeBytes(UTF8_ENCODER.encode(value));
     this.writeUint8(0);
   }


### PR DESCRIPTION
- **[Breaking change]** Rename `readNulTerminatedUtf8` to `readNulUtf8` and `writeNulTerminatedUtf8` to `writeNulUtf8`.