### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.4.0 (2021-05-02)
 
 - **[Breaking change]** Update to use native ESM.
 - **[Feature]** Add `Float64LE32` support.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-flash/stream",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "homepage": "https://github.com/open-flash/stream",
   "description": "Streams for Open Flash",
   "publishConfig": {


### PR DESCRIPTION
- **[Breaking change]** Update to use native ESM.
- **[Feature]** Add `Float64LE32` support.
- **[Internal]** Update dependencies.