### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.0 (2021-07-23)
 
 - **[Breaking change]** Drop `lib` prefix and `.js` extension from deep-imports.
 - **[Fix]** Update dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-flash/stream",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "https://github.com/open-flash/stream",
   "description": "Streams for Open Flash",
   "publishConfig": {


### PR DESCRIPTION
- **[Breaking change]** Drop `lib` prefix and `.js` extension from deep-imports.
- **[Fix]** Update dependencies.